### PR TITLE
Use async module / Add syntax highlighting to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This plugin requires Grunt `~0.4.0`
 ## Example
 
 
-```
+```js
 module.exports = function(grunt) {
 
   

--- a/package.json
+++ b/package.json
@@ -29,11 +29,12 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "grunt-lib-contrib": "~0.6.1"
+    "grunt-lib-contrib": "~0.6.1",
+    "async": "~0.2.10"
   },
   "devDependencies": {
-    "grunt-contrib-clean": "~0.4.0",
-    "grunt": "~0.4.1"
+    "grunt-contrib-clean": "~0.5.0",
+    "grunt": "~0.4.2"
   },
   "peerDependencies": {
     "grunt": "~0.4.1"

--- a/tasks/webp.js
+++ b/tasks/webp.js
@@ -71,6 +71,7 @@ Experimental Options:
 
 module.exports = function(grunt) {
   var path = require('path');
+  var async = require('async');
   grunt.registerMultiTask('webp', 'WebP image format converter.', function() {
     /**
      * Retrieves defined options.
@@ -86,7 +87,7 @@ module.exports = function(grunt) {
     }
 
     // Iterate over all src-dest file pairs.
-    grunt.util.async.forEachSeries(this.files, function(f, next) {
+    async.eachSeries(this.files, function(f, next) {
       
       /**
        * Create folder for the dest file


### PR DESCRIPTION
[`grunt.util.async`](http://gruntjs.com/api/grunt.util#grunt.util.async) is [deprecated](http://gruntjs.com/blog/2013-11-21-grunt-0.4.2-released).
