### PR TITLE
Remove grunt-lib-contrib module

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "grunt-lib-contrib": "~0.6.1",
     "async": "~0.2.10"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "async": "~0.2.10"
+    "async": "~0.9.0"
   },
   "devDependencies": {
     "grunt-contrib-clean": "~0.5.0",


### PR DESCRIPTION
This plugin doesn’t use [grunt-lib-contrib](https://github.com/gruntjs/grunt-lib-contrib) and it is deprecated.

This PR resolves #11.
